### PR TITLE
KUBEDR-6801: Support file mount and ls

### DIFF
--- a/snapshot/snapshotfs/objref.go
+++ b/snapshot/snapshotfs/objref.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/kopia/kopia/fs"
+	"github.com/kopia/kopia/fs/virtualfs"
 	"github.com/kopia/kopia/repo"
 	"github.com/kopia/kopia/repo/manifest"
 	"github.com/kopia/kopia/repo/object"
@@ -189,7 +190,12 @@ func FilesystemDirectoryFromIDWithPath(ctx context.Context, rep repo.Repository,
 		return dir, nil
 	}
 
-	return nil, errors.Errorf("%v is not a directory object", rootID)
+	// if entry is a file, simulate a directory with a single file entry
+	if file, ok := e.(fs.File); ok {
+		return virtualfs.NewStaticDirectory("root", []fs.Entry{file}), nil
+	}
+
+	return nil, errors.Errorf("%v is not a directory or a file object", rootID)
 }
 
 func consistentSnapshotMetadata(m1, m2 *snapshot.Manifest) bool {


### PR DESCRIPTION
Support file mount and ls
```
~/go/bin/kopia ls -l Ix82bfa07a861ab6f7d7d4a5c0c23f6aa2
-rw-rw----   1073741824 2025-05-30 14:03:15 EDT Ix82bfa07a861ab6f7d7d4a5c0c23f6aa2 tinyvm-disk-0-2sdie
```

```
# /home/davidz/go/bin/kopia mount Ix82bfa07a861ab6f7d7d4a5c0c23f6aa2 /mnt/1
Mounted 'Ix82bfa07a861ab6f7d7d4a5c0c23f6aa2' on /mnt/1

# ls -l /mnt/1
total 1048576
-rw-rw---- 1 root disk 1073741824 May 30 14:03 tinyvm-disk-0-2sdie

# hexdump -C /mnt/1/tinyvm-disk-0-2sdie | head
00000000  33 ed 90 90 90 90 90 90  90 90 90 90 90 90 90 90  |3...............|
00000010  90 90 90 90 90 90 90 90  90 90 90 90 90 90 90 90  |................|
00000020  33 ed fa 8e d5 bc 00 7c  fb fc 66 31 db 66 31 c9  |3......|..f1.f1.|
00000030  66 53 66 51 06 57 8e dd  8e c5 52 be 00 7c bf 00  |fSfQ.W....R..|..|
00000040  06 b9 00 01 f3 a5 ea 4b  06 00 00 52 b4 41 bb aa  |.......K...R.A..|
00000050  55 31 c9 30 f6 f9 cd 13  72 16 81 fb 55 aa 75 10  |U1.0....r...U.u.|
00000060  83 e1 01 74 0b 66 c7 06  f1 06 b4 42 eb 15 eb 00  |...t.f.....B....|
00000070  5a 51 b4 08 cd 13 83 e1  3f 5b 51 0f b6 c6 40 50  |ZQ......?[Q...@P|
00000080  f7 e1 53 52 50 bb 00 7c  b9 04 00 66 a1 b0 07 e8  |..SRP..|...f....|
00000090  44 00 0f 82 80 00 66 40  80 c7 02 e2 f2 66 81 3e  |D.....f@.....f.>|
```