### PR TITLE
KUBEDR-7338: Create a PVC and use it as Kopia cache

### DIFF
--- a/repo/content/committed_read_manager.go
+++ b/repo/content/committed_read_manager.go
@@ -440,6 +440,7 @@ func metadataCacheSizeSweepSettings(caching *CachingOptions) cache.SweepSettings
 func indexBlobCacheSweepSettings(caching *CachingOptions) cache.SweepSettings {
 	return cache.SweepSettings{
 		MaxSizeBytes: caching.EffectiveMetadataCacheSizeBytes(),
+		LimitBytes:   caching.MetadataCacheSizeLimitBytes,
 		MinSweepAge:  caching.MinMetadataSweepAge.DurationOrDefault(DefaultMetadataCacheSweepAge),
 	}
 }


### PR DESCRIPTION
Set hard limit for index-blobs cache size.
